### PR TITLE
Add version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,10 @@ builds:
       - linux
       - windows
       - darwin
+    ldflags:
+      - -X github.com/cbsinteractive/tfc-cli/cmd.Major={{ .Major }}
+      - -X github.com/cbsinteractive/tfc-cli/cmd.Minor={{ .Minor }}
+      - -X github.com/cbsinteractive/tfc-cli/cmd.Patch={{ .Patch }}
 dockers:
   - goos: linux
     goarch: amd64

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/go-tfe"
 )
 
+var Version = "development"
+
 type Usage string
 
 const (
@@ -54,6 +56,7 @@ func root(options ExecuteOpts, args []string, os dependencyCaller, w io.Writer) 
 	}
 	runners := []Runner{
 		NewStateVersionsCmd(os, w),
+		NewVersionCmd(w),
 	}
 	subcommand := args[0]
 	for _, r := range runners {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -10,7 +10,13 @@ import (
 	"github.com/hashicorp/go-tfe"
 )
 
-var Version = "development"
+// Variables set at build time used to generate the version number
+var (
+	Major        string = "0"
+	Minor        string = "0"
+	Patch        string = "0"
+	ReleaseLabel string
+)
 
 type Usage string
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/go-tfe"
+)
+
+type defaultFakeDeps struct{}
+
+func (c defaultFakeDeps) osLookupEnv(key string) (string, bool) {
+	return "", false
+}
+
+func (c defaultFakeDeps) clientWorkspacesRead(
+	_ *tfe.Client,
+	ctx context.Context,
+	organization string,
+	workspace string,
+) (*tfe.Workspace, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c defaultFakeDeps) clientStateVersionsCurrentWithOptions(
+	_ *tfe.Client,
+	ctx context.Context,
+	workspaceID string,
+	options *tfe.StateVersionCurrentOptions,
+) (*tfe.StateVersion, error) {
+	return nil, errors.New("not implemented")
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,28 @@
+package cmd
+
+import "io"
+
+type VersionCmd struct {
+	w io.Writer
+}
+
+func NewVersionCmd(w io.Writer) *VersionCmd {
+	return &VersionCmd{
+		w: w,
+	}
+}
+
+func (c *VersionCmd) Name() string {
+	return "version"
+}
+
+func (c *VersionCmd) Init([]string) error {
+	return nil
+}
+
+func (c *VersionCmd) Run() error {
+	if _, err := c.w.Write([]byte(Version)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "io"
+import (
+	"fmt"
+	"io"
+)
 
 type VersionCmd struct {
 	w io.Writer
@@ -21,7 +24,11 @@ func (c *VersionCmd) Init([]string) error {
 }
 
 func (c *VersionCmd) Run() error {
-	if _, err := c.w.Write([]byte(Version)); err != nil {
+	label := ""
+	if ReleaseLabel != "" {
+		label = fmt.Sprintf("-%s", ReleaseLabel)
+	}
+	if _, err := c.w.Write([]byte(fmt.Sprintf("%s.%s.%s%s", Major, Minor, Patch, label))); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -8,17 +8,36 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	args := []string{"version"}
-	options := ExecuteOpts{
-		AppName: "tfc-cli",
+	testConfigs := []struct {
+		description    string
+		major          string
+		minor          string
+		patch          string
+		label          string
+		expectedOutput string
+	}{
+		{"default", "1", "2", "3", "", "1.2.3"},
+		{"includes label", "1", "2", "3", "foo", "1.2.3-foo"},
 	}
-	var buff bytes.Buffer
-	if err := root(
-		options,
-		args,
-		defaultFakeDeps{},
-		&buff); err != nil {
-		t.Fatal(err)
+	for _, d := range testConfigs {
+		t.Run(d.description, func(t *testing.T) {
+			Major = d.major
+			Minor = d.minor
+			Patch = d.patch
+			ReleaseLabel = d.label
+			args := []string{"version"}
+			options := ExecuteOpts{
+				AppName: "tfc-cli",
+			}
+			var buff bytes.Buffer
+			if err := root(
+				options,
+				args,
+				defaultFakeDeps{},
+				&buff); err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, d.expectedOutput, buff.String())
+		})
 	}
-	assert.Equal(t, "development", buff.String())
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersion(t *testing.T) {
+	args := []string{"version"}
+	options := ExecuteOpts{
+		AppName: "tfc-cli",
+	}
+	var buff bytes.Buffer
+	if err := root(
+		options,
+		args,
+		defaultFakeDeps{},
+		&buff); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "development", buff.String())
+}


### PR DESCRIPTION
Uses linker flags to supply version number components at build time.