### PR TITLE
VDE 1904 refactor output handling

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -49,7 +49,8 @@ type WorkspaceOpts struct {
 
 type ExecuteOpts struct {
 	AppName string
-	Writer  io.Writer
+	Stdout  io.Writer
+	Stderr  io.Writer
 }
 
 type commonOpts struct {
@@ -79,30 +80,30 @@ func Execute(options ExecuteOpts) error {
 func root(options ExecuteOpts, args []string, deps dependencyProxies) error {
 	if len(args) < 1 {
 		err := errors.New("no subcommand given")
-		outputError(options.Writer, err)
+		outputError(options.Stderr, err)
 		return err
 	}
 	runners := []Runner{
-		NewStateVersionsCmd(deps, options.Writer),
-		NewVersionCmd(options.Writer),
+		NewStateVersionsCmd(deps, options.Stdout),
+		NewVersionCmd(options.Stdout),
 		NewWorkspacesCmd(options, deps),
 	}
 	subcommand := args[0]
 	for _, r := range runners {
 		if r.Name() == subcommand {
 			if err := r.Init(args[1:]); err != nil {
-				outputError(options.Writer, err)
+				outputError(options.Stderr, err)
 				return err
 			}
 			if err := r.Run(); err != nil {
-				outputError(options.Writer, err)
+				outputError(options.Stderr, err)
 				return err
 			}
 			return nil
 		}
 	}
 	err := fmt.Errorf("unknown subcommand: %s", subcommand)
-	outputError(options.Writer, err)
+	outputError(options.Stderr, err)
 	return err
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -57,11 +57,6 @@ type commonOpts struct {
 	quiet bool
 }
 
-type CommandResult struct {
-	Error  string      `json:"error,omitempty"`
-	Result interface{} `json:"result,omitempty"`
-}
-
 func Execute(options ExecuteOpts) error {
 	return root(
 		options,

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -22,20 +22,28 @@ func variableFromKey(client *tfe.Client, proxy clientProxy, ctx context.Context,
 	return nil, fmt.Errorf("variable %s not found", key)
 }
 
-func newCommandResultOutput(v interface{}) []byte {
-	d, _ := json.Marshal(CommandResult{
-		Result: v,
-	})
-	return append(d, '\n')
+type CommandResult struct {
+	Result interface{} `json:"result,omitempty"`
 }
 
-func newCommandErrorOutput(err error) []byte {
-	d, _ := json.Marshal(CommandResult{
-		Error: err.Error(),
-	})
-	return append(d, '\n')
+func output(w io.Writer, result interface{}) {
+	r := CommandResult{
+		Result: result,
+	}
+	d, _ := json.Marshal(r)
+	d = append(d, '\n')
+	w.Write(d)
+}
+
+type CommandError struct {
+	Error string `json:"error,omitempty"`
 }
 
 func outputError(w io.Writer, err error) {
-	w.Write([]byte(fmt.Sprintf("%s\n", err)))
+	r := CommandError{
+		Error: err.Error(),
+	}
+	d, _ := json.Marshal(r)
+	d = append(d, '\n')
+	w.Write(d)
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/hashicorp/go-tfe"
 )
@@ -33,4 +34,8 @@ func newCommandErrorOutput(err error) []byte {
 		Error: err.Error(),
 	})
 	return append(d, '\n')
+}
+
+func outputError(w io.Writer, err error) {
+	w.Write([]byte(fmt.Sprintf("%s\n", err)))
 }

--- a/cmd/state_versions.go
+++ b/cmd/state_versions.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"io"
 )
 
@@ -23,11 +22,6 @@ func (c *StateVersionsCmd) Name() string {
 }
 
 func (c *StateVersionsCmd) Init(args []string) error {
-	if len(args) < 1 {
-		err := errors.New("no subcommand given")
-		c.w.Write(newCommandErrorOutput(err))
-		return err
-	}
 	runners := []Runner{
 		NewStateVersionsCurrentCmd(c.deps, c.w),
 	}

--- a/cmd/state_versions_current.go
+++ b/cmd/state_versions_current.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"io"
 )
 
@@ -23,11 +22,6 @@ func (c *StateVersionsCurrentCmd) Name() string {
 }
 
 func (c *StateVersionsCurrentCmd) Init(args []string) error {
-	if len(args) < 1 {
-		err := errors.New("no subcommand given")
-		c.w.Write(newCommandErrorOutput(err))
-		return err
-	}
 	runners := []Runner{
 		NewStateVersionsCurrentGetOutputCmd(c.deps, c.w),
 	}

--- a/cmd/state_versions_current_getoutput_test.go
+++ b/cmd/state_versions_current_getoutput_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/hashicorp/go-tfe"
@@ -85,7 +86,9 @@ func TestStateVersionsCurrentGetOutput(t *testing.T) {
 
 			// Verify
 			assert.Nil(t, err)
-			assert.Contains(t, buff.String(), d.expectedValue)
+			r := CommandResult{}
+			json.Unmarshal(buff.Bytes(), &r)
+			assert.Equal(t, d.expectedValue, r.Result.(map[string]interface{})["value"].(string))
 		})
 	}
 }

--- a/cmd/state_versions_current_getoutput_test.go
+++ b/cmd/state_versions_current_getoutput_test.go
@@ -60,7 +60,7 @@ func TestStateVersionsCurrentGetOutput(t *testing.T) {
 			var buff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Writer:  &buff,
+				Stdout:  &buff,
 			}
 			// Set up expectations
 			mockedOSProxy := mockOSProxy{}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -29,7 +29,7 @@ func TestVersion(t *testing.T) {
 			var buff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Writer:  &buff,
+				Stdout:  &buff,
 			}
 
 			// Code under test

--- a/cmd/workspaces.go
+++ b/cmd/workspaces.go
@@ -15,7 +15,7 @@ func NewWorkspacesCmd(options ExecuteOpts, deps dependencyProxies) *WorkspacesCm
 	return &WorkspacesCmd{
 		appName: options.AppName,
 		deps:    deps,
-		w:       options.Writer,
+		w:       options.Stdout,
 	}
 }
 

--- a/cmd/workspaces.go
+++ b/cmd/workspaces.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"io"
 )
 
@@ -25,9 +24,6 @@ func (c *WorkspacesCmd) Name() string {
 }
 
 func (c *WorkspacesCmd) Init(args []string) error {
-	if len(args) < 1 {
-		return errors.New("no subcommand given")
-	}
 	runners := []Runner{
 		newWorkspacesCreateCmd(c.deps, c.w, c.appName),
 		newWorkspacesDeleteCmd(c.deps, c.w),

--- a/cmd/workspaces_create.go
+++ b/cmd/workspaces_create.go
@@ -36,17 +36,13 @@ func (c *workspacesCreateCmd) Name() string {
 
 func (c *workspacesCreateCmd) Init(args []string) error {
 	if err := c.fs.Parse(args); err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	if err := processCommonInputs(&c.OrgOpts.token, &c.OrgOpts.name, c.deps.os.lookupEnv); err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	if c.WorkspaceOpts.name == "" {
-		err := errors.New("-workspace argument is required")
-		c.w.Write(newCommandErrorOutput(err))
-		return err
+		return errors.New("-workspace argument is required")
 	}
 	return nil
 }
@@ -56,7 +52,6 @@ func (c *workspacesCreateCmd) Run() error {
 		Token: c.OrgOpts.token,
 	})
 	if err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	description := fmt.Sprintf("Created by %s", c.appName)
@@ -65,13 +60,10 @@ func (c *workspacesCreateCmd) Run() error {
 		Description: &description,
 	})
 	if err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	if workspace == nil {
-		err := errors.New("workspace and error both nil")
-		c.w.Write(newCommandErrorOutput(err))
-		return err
+		return errors.New("workspace and error both nil")
 	}
 	return nil
 }

--- a/cmd/workspaces_create_test.go
+++ b/cmd/workspaces_create_test.go
@@ -42,7 +42,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			var buff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Writer:  &buff,
+				Stdout:  &buff,
 			}
 			// Set up expectations
 			mockedOSProxy := mockOSProxy{}

--- a/cmd/workspaces_delete_test.go
+++ b/cmd/workspaces_delete_test.go
@@ -32,7 +32,7 @@ func TestWorkspacesDelete(t *testing.T) {
 			var buff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Writer:  &buff,
+				Stdout:  &buff,
 			}
 			// Set up expectations
 			mockedOSProxy := mockOSProxy{}

--- a/cmd/workspaces_show.go
+++ b/cmd/workspaces_show.go
@@ -63,9 +63,6 @@ func (c *workspacesShowCmd) Run() error {
 	}
 	w, err := c.deps.client.workspaces.read(client, context.Background(), c.OrgOpts.name, c.WorkspaceOpts.name)
 	if err != nil {
-		if !c.commonOpts.quiet {
-			c.w.Write(newCommandErrorOutput(err))
-		}
 		return err
 	}
 	if w == nil {

--- a/cmd/workspaces_show.go
+++ b/cmd/workspaces_show.go
@@ -56,9 +56,6 @@ func (c *workspacesShowCmd) Run() error {
 		Token: c.OrgOpts.token,
 	})
 	if err != nil {
-		if !c.commonOpts.quiet {
-			c.w.Write(newCommandErrorOutput(err))
-		}
 		return err
 	}
 	w, err := c.deps.client.workspaces.read(client, context.Background(), c.OrgOpts.name, c.WorkspaceOpts.name)
@@ -66,18 +63,14 @@ func (c *workspacesShowCmd) Run() error {
 		return err
 	}
 	if w == nil {
-		err := errors.New("workspace and error both nil")
-		if !c.commonOpts.quiet {
-			c.w.Write(newCommandErrorOutput(err))
-		}
-		return err
+		return errors.New("workspace and error both nil")
 	}
 	if c.commonOpts.quiet {
 		return nil
 	}
-	c.w.Write(newCommandResultOutput(WorkspacesShowCommandResult{
+	output(c.w, WorkspacesShowCommandResult{
 		ID:          w.ID,
 		Description: w.Description,
-	}))
+	})
 	return nil
 }

--- a/cmd/workspaces_show_test.go
+++ b/cmd/workspaces_show_test.go
@@ -36,8 +36,8 @@ func TestWorkspacesShow(t *testing.T) {
 		workspace           string
 		workspaceShowResult *tfe.Workspace
 		expectedError       error
-		expectOutput        bool
 		expectedOutput      string
+		expectedErrorOutput string
 	}{
 		{
 			"show existing workspace",
@@ -47,8 +47,8 @@ func TestWorkspacesShow(t *testing.T) {
 			"foo",
 			newDefaultWorkspace(),
 			nil,
-			true,
 			newDefaultCommandResult(),
+			"",
 		},
 		{
 			"show existing workspace (quiet)",
@@ -58,8 +58,8 @@ func TestWorkspacesShow(t *testing.T) {
 			"foo",
 			newDefaultWorkspace(),
 			nil,
-			false,
-			"unused",
+			"",
+			"",
 		},
 		{
 			"show missing workspace",
@@ -69,17 +69,18 @@ func TestWorkspacesShow(t *testing.T) {
 			"foo",
 			nil,
 			errors.New("resource not found"),
-			true,
+			"",
 			"resource not found\n",
 		},
 	}
 	for _, d := range testConfigs {
 		t.Run(d.description, func(t *testing.T) {
 			args := append([]string{"workspaces", "show"}, d.args...)
-			var buff bytes.Buffer
+			var outBuff, errBuff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Writer:  &buff,
+				Stdout:  &outBuff,
+				Stderr:  &errBuff,
 			}
 			// Set up expectations
 			mockedOSProxy := mockOSProxy{}
@@ -108,11 +109,8 @@ func TestWorkspacesShow(t *testing.T) {
 			}
 			mockedOSProxy.AssertExpectations(t)
 			mockedWorkspacesProxy.AssertExpectations(t)
-			if !d.expectOutput {
-				assert.Empty(t, buff.String())
-			} else {
-				assert.Equal(t, d.expectedOutput, buff.String())
-			}
+			assert.Equal(t, d.expectedOutput, outBuff.String())
+			assert.Equal(t, d.expectedErrorOutput, errBuff.String())
 		})
 	}
 }

--- a/cmd/workspaces_show_test.go
+++ b/cmd/workspaces_show_test.go
@@ -70,7 +70,7 @@ func TestWorkspacesShow(t *testing.T) {
 			nil,
 			errors.New("resource not found"),
 			"",
-			"resource not found\n",
+			"{\"error\":\"resource not found\"}\n",
 		},
 	}
 	for _, d := range testConfigs {

--- a/cmd/workspaces_show_test.go
+++ b/cmd/workspaces_show_test.go
@@ -18,13 +18,15 @@ func TestWorkspacesShow(t *testing.T) {
 			Description: "some workspace description",
 		}
 	}
-	newDefaultCommandResult := func() CommandResult {
-		return CommandResult{
-			Result: map[string]interface{}{
-				"id":          "some workspace id",
-				"description": "some workspace description",
+	newDefaultCommandResult := func() string {
+		d, _ := json.Marshal(CommandResult{
+			Result: WorkspacesShowCommandResult{
+				ID:          "some workspace id",
+				Description: "some workspace description",
 			},
-		}
+		})
+		d = append(d, '\n')
+		return string(d)
 	}
 	testConfigs := []struct {
 		description         string
@@ -33,9 +35,9 @@ func TestWorkspacesShow(t *testing.T) {
 		token               string
 		workspace           string
 		workspaceShowResult *tfe.Workspace
-		workspaceShowError  error
+		expectedError       error
 		expectOutput        bool
-		expectedOutput      CommandResult
+		expectedOutput      string
 	}{
 		{
 			"show existing workspace",
@@ -57,7 +59,7 @@ func TestWorkspacesShow(t *testing.T) {
 			newDefaultWorkspace(),
 			nil,
 			false,
-			newDefaultCommandResult(),
+			"unused",
 		},
 		{
 			"show missing workspace",
@@ -68,9 +70,7 @@ func TestWorkspacesShow(t *testing.T) {
 			nil,
 			errors.New("resource not found"),
 			true,
-			CommandResult{
-				Error: "resource not found",
-			},
+			"resource not found\n",
 		},
 	}
 	for _, d := range testConfigs {
@@ -86,7 +86,7 @@ func TestWorkspacesShow(t *testing.T) {
 			mockedOSProxy.On("lookupEnv", "TFC_ORG").Return(d.organization, true)
 			mockedOSProxy.On("lookupEnv", "TFC_TOKEN").Return(d.token, true)
 			mockedWorkspacesProxy := mockWorkspacesProxy{}
-			mockedWorkspacesProxy.On("read", mock.Anything, mock.Anything, d.organization, d.workspace).Return(d.workspaceShowResult, d.workspaceShowError)
+			mockedWorkspacesProxy.On("read", mock.Anything, mock.Anything, d.organization, d.workspace).Return(d.workspaceShowResult, d.expectedError)
 
 			// Code under test
 			err := root(
@@ -101,8 +101,8 @@ func TestWorkspacesShow(t *testing.T) {
 			)
 
 			// Verify
-			if d.workspaceShowError != nil {
-				assert.Same(t, d.workspaceShowError, err)
+			if d.expectedError != nil {
+				assert.Same(t, d.expectedError, err)
 			} else {
 				assert.Nil(t, err)
 			}
@@ -111,10 +111,7 @@ func TestWorkspacesShow(t *testing.T) {
 			if !d.expectOutput {
 				assert.Empty(t, buff.String())
 			} else {
-				var result CommandResult
-				err := json.Unmarshal(buff.Bytes(), &result)
-				assert.Nil(t, err)
-				assert.Equal(t, d.expectedOutput, result)
+				assert.Equal(t, d.expectedOutput, buff.String())
 			}
 		})
 	}

--- a/cmd/workspaces_variables_create.go
+++ b/cmd/workspaces_variables_create.go
@@ -61,7 +61,6 @@ func (c *workspacesVariablesCreateCmd) Name() string {
 
 func (c *workspacesVariablesCreateCmd) Init(args []string) error {
 	if err := c.fs.Parse(args); err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	if err := processCommonInputs(
@@ -69,18 +68,13 @@ func (c *workspacesVariablesCreateCmd) Init(args []string) error {
 		&c.OrgOpts.name,
 		c.deps.os.lookupEnv,
 	); err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	if c.WorkspaceOpts.name == "" {
-		err := errors.New("-workspace argument is required")
-		c.w.Write(newCommandErrorOutput(err))
-		return err
+		return errors.New("-workspace argument is required")
 	}
 	if c.VariableCreateOpts.key == "" {
-		err := errors.New("-key argument is required")
-		c.w.Write(newCommandErrorOutput(err))
-		return err
+		return errors.New("-key argument is required")
 	}
 	switch c.VariableCreateOpts.categoryRaw {
 	case "terraform":
@@ -88,9 +82,7 @@ func (c *workspacesVariablesCreateCmd) Init(args []string) error {
 	case "env":
 		c.VariableCreateOpts.category = tfe.CategoryEnv
 	default:
-		err := fmt.Errorf(`invalid category: "%s"`, c.VariableCreateOpts.categoryRaw)
-		c.w.Write(newCommandErrorOutput(err))
-		return err
+		return fmt.Errorf(`invalid category: "%s"`, c.VariableCreateOpts.categoryRaw)
 	}
 	return nil
 }
@@ -101,12 +93,10 @@ func (c *workspacesVariablesCreateCmd) Run() error {
 		Token: c.OrgOpts.token,
 	})
 	if err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	w, err := c.deps.client.workspaces.read(client, ctx, c.OrgOpts.name, c.WorkspaceOpts.name)
 	if err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	options := tfe.VariableCreateOptions{
@@ -119,15 +109,12 @@ func (c *workspacesVariablesCreateCmd) Run() error {
 	}
 	v, err := c.deps.client.variables.create(client, ctx, w.ID, options)
 	if err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	if v == nil {
-		err := errors.New("variable and error both nil")
-		c.w.Write(newCommandErrorOutput(err))
-		return err
+		return errors.New("variable and error both nil")
 	}
-	c.w.Write(newCommandResultOutput(WorkspacesVariablesCreateCommandResult{
+	output(c.w, WorkspacesVariablesCreateCommandResult{
 		ID:  v.ID,
 		Key: v.Key,
 		// The API provides an empty string if the variable is set as sensitive
@@ -136,6 +123,6 @@ func (c *workspacesVariablesCreateCmd) Run() error {
 		Description: v.Description,
 		Sensitive:   v.Sensitive,
 		HCL:         v.HCL,
-	}))
+	})
 	return nil
 }

--- a/cmd/workspaces_variables_create_test.go
+++ b/cmd/workspaces_variables_create_test.go
@@ -85,7 +85,7 @@ func TestWorkspacesVariablesCreate(t *testing.T) {
 			var buff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Writer:  &buff,
+				Stdout:  &buff,
 			}
 			// Set up expectations
 			mockedOSProxy := mockOSProxy{}

--- a/cmd/workspaces_variables_delete_test.go
+++ b/cmd/workspaces_variables_delete_test.go
@@ -44,7 +44,7 @@ func TestWorkspacesVariablesDelete(t *testing.T) {
 			var buff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Writer:  &buff,
+				Stdout:  &buff,
 			}
 			// Set up expectations
 			mockedOSProxy := mockOSProxy{}

--- a/cmd/workspaces_variables_list_test.go
+++ b/cmd/workspaces_variables_list_test.go
@@ -60,7 +60,7 @@ func TestWorkspacesVariablesList(t *testing.T) {
 			var buff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Writer:  &buff,
+				Stdout:  &buff,
 			}
 			mockedOSProxy := mockOSProxy{}
 			mockedOSProxy.On("lookupEnv", "TFC_ORG").Return(d.organization, true)

--- a/cmd/workspaces_variables_update_description.go
+++ b/cmd/workspaces_variables_update_description.go
@@ -91,10 +91,10 @@ func (c *workspacesVariablesUpdateDescriptionCmd) Run() error {
 	if u == nil {
 		return errors.New("variable and error both nil")
 	}
-	c.w.Write(newCommandResultOutput(WorkspacesVariablesUpdateDescriptionCommandResult{
+	output(c.w, WorkspacesVariablesUpdateDescriptionCommandResult{
 		ID:          u.ID,
 		Key:         u.Key,
 		Description: u.Description,
-	}))
+	})
 	return nil
 }

--- a/cmd/workspaces_variables_update_description_test.go
+++ b/cmd/workspaces_variables_update_description_test.go
@@ -63,7 +63,7 @@ func TestWorkspacesVariablesUpdateDescription(t *testing.T) {
 			var buff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Writer:  &buff,
+				Stdout:  &buff,
 			}
 			// Set up expectations
 			mockedOSProxy := mockOSProxy{}

--- a/cmd/workspaces_variables_update_sensitive.go
+++ b/cmd/workspaces_variables_update_sensitive.go
@@ -91,10 +91,10 @@ func (c *workspacesVariablesUpdateSensitiveCmd) Run() error {
 	if u == nil {
 		return errors.New("variable and error both nil")
 	}
-	c.w.Write(newCommandResultOutput(WorkspacesVariablesUpdateSensitiveCommandResult{
+	output(c.w, WorkspacesVariablesUpdateSensitiveCommandResult{
 		ID:        u.ID,
 		Key:       u.Key,
 		Sensitive: u.Sensitive,
-	}))
+	})
 	return nil
 }

--- a/cmd/workspaces_variables_update_sensitive_test.go
+++ b/cmd/workspaces_variables_update_sensitive_test.go
@@ -46,7 +46,7 @@ func TestWorkspacesVariablesUpdateSensitive(t *testing.T) {
 			var buff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Writer:  &buff,
+				Stdout:  &buff,
 			}
 			// Set up expectations
 			mockedOSProxy := mockOSProxy{}

--- a/cmd/workspaces_variables_update_value.go
+++ b/cmd/workspaces_variables_update_value.go
@@ -47,7 +47,6 @@ func (c *workspacesVariablesUpdateValueCmd) Name() string {
 
 func (c *workspacesVariablesUpdateValueCmd) Init(args []string) error {
 	if err := c.fs.Parse(args); err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	if err := processCommonInputs(
@@ -55,18 +54,13 @@ func (c *workspacesVariablesUpdateValueCmd) Init(args []string) error {
 		&c.OrgOpts.name,
 		c.deps.os.lookupEnv,
 	); err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	if c.WorkspaceOpts.name == "" {
-		err := errors.New("-workspace argument is required")
-		c.w.Write(newCommandErrorOutput(err))
-		return err
+		return errors.New("-workspace argument is required")
 	}
 	if c.VariableUpdateValueOpts.key == "" {
-		err := errors.New("-key argument is required")
-		c.w.Write(newCommandErrorOutput(err))
-		return err
+		return errors.New("-key argument is required")
 	}
 	return nil
 }
@@ -77,17 +71,14 @@ func (c *workspacesVariablesUpdateValueCmd) Run() error {
 		Token: c.OrgOpts.token,
 	})
 	if err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	w, err := c.deps.client.workspaces.read(client, ctx, c.OrgOpts.name, c.WorkspaceOpts.name)
 	if err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	v, err := variableFromKey(client, c.deps.client, ctx, w.ID, c.VariableUpdateValueOpts.key)
 	if err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	options := tfe.VariableUpdateOptions{
@@ -95,18 +86,15 @@ func (c *workspacesVariablesUpdateValueCmd) Run() error {
 	}
 	u, err := c.deps.client.workspacesCommands.variables.update(client, ctx, w.ID, v.ID, options)
 	if err != nil {
-		c.w.Write(newCommandErrorOutput(err))
 		return err
 	}
 	if u == nil {
-		err := errors.New("variable and error both nil")
-		c.w.Write(newCommandErrorOutput(err))
-		return err
+		return errors.New("variable and error both nil")
 	}
-	c.w.Write(newCommandResultOutput(WorkspacesVariablesUpdateValueCommandResult{
+	output(c.w, WorkspacesVariablesUpdateValueCommandResult{
 		ID:    u.ID,
 		Key:   u.Key,
 		Value: u.Value,
-	}))
+	})
 	return nil
 }

--- a/cmd/workspaces_variables_update_value_test.go
+++ b/cmd/workspaces_variables_update_value_test.go
@@ -47,7 +47,7 @@ func TestWorkspacesVariablesUpdateValue(t *testing.T) {
 			var buff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Writer:  &buff,
+				Stdout:  &buff,
 			}
 			// Set up expectations
 			mockedOSProxy := mockOSProxy{}

--- a/main.go
+++ b/main.go
@@ -9,10 +9,12 @@ import (
 func main() {
 	options := cmd.ExecuteOpts{
 		AppName: "tfc-cli",
-		Writer:  os.Stdout,
+		Stdout:  os.Stdout,
+		Stderr:  os.Stderr,
 	}
 	if err := cmd.Execute(options); err != nil {
-		// Command handlers are responsible for output
+		// If an error took place, code within the testable part of the
+		// application was expected to present output via os.Stderr
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
The changes to the code aim to refactor how `tfc-cli` produces its output so the it is more like `azurermfutures-cli`.
I have not tested the codes yet, so I am not sure if my edits are correct and if they actually accomplish the goal.
Thank you in advance for reviewing my PR!