### PR TITLE
Add VCS options for `workspaces create` subcommand

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -22,6 +22,7 @@ const (
 	OrgUsage                 Usage = "Organization name"
 	TokenUsage               Usage = "Organization token"
 	WorkspaceUsage           Usage = "Workspace name"
+	WorkingDirectoryUsage    Usage = "The directory that Terraform will execute within"
 	OutputNameUsage          Usage = "Output variable name"
 	QuietUsage               Usage = "Quiet output"
 	VariableKeyUsage         Usage = "Variable key"
@@ -30,6 +31,9 @@ const (
 	VariableCategoryUsage    Usage = "Variable category"
 	VariableHCLUsage         Usage = "Indicates whether variable value is HCL-formatted"
 	VariableSensitiveUsage   Usage = "Indicates whether variable is sensitive"
+	VCSIdentifierUsage       Usage = "The associated VCS repository (org/repo)"
+	VCSBranchUsage           Usage = "VCS branch name"
+	VCSOAuthTokenIDUsage     Usage = "VCS OAuth token ID"
 )
 
 type Runner interface {
@@ -44,7 +48,11 @@ type OrgOpts struct {
 }
 
 type WorkspaceOpts struct {
-	name string
+	name             string
+	workingDirectory string
+	vcsIdentifier    string
+	vcsBranch        string
+	vcsOAuthTokenID  string
 }
 
 type ExecuteOpts struct {

--- a/cmd/workspaces.go
+++ b/cmd/workspaces.go
@@ -29,6 +29,7 @@ func (c *WorkspacesCmd) Init(args []string) error {
 		newWorkspacesDeleteCmd(c.deps, c.w),
 		newWorkspacesShowCmd(c.deps, c.w),
 		newWorkspacesVariablesCmd(c.deps, c.w),
+		newWorkspacesVCSCmd(c.deps, c.w),
 	}
 	return processSubcommand(&c.r, args, runners)
 }

--- a/cmd/workspaces_create.go
+++ b/cmd/workspaces_create.go
@@ -83,7 +83,7 @@ func (c *workspacesCreateCmd) Run() error {
 		}
 		opts.VCSRepo = &vcsOpts
 	}
-	w, err := c.deps.client.workspaces.create(
+	workspace, err := c.deps.client.workspaces.create(
 		client,
 		context.Background(),
 		c.OrgOpts.name,
@@ -92,12 +92,12 @@ func (c *workspacesCreateCmd) Run() error {
 	if err != nil {
 		return err
 	}
-	if w == nil {
+	if workspace == nil {
 		return errors.New("workspace and error both nil")
 	}
 	output(c.w, WorkspacesCreateCommandResult{
-		ID:          w.ID,
-		Description: w.Description,
+		ID:          workspace.ID,
+		Description: workspace.Description,
 	})
 	return nil
 }

--- a/cmd/workspaces_create_test.go
+++ b/cmd/workspaces_create_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/hashicorp/go-tfe"
@@ -10,11 +11,29 @@ import (
 )
 
 func TestWorkspacesCreate(t *testing.T) {
-	newWorkspaceCreateOptions := (func(name string) tfe.WorkspaceCreateOptions {
+	newWorkspaceCreateOptions := (func(name string, workingDirectory string, vcsRepoOpts *tfe.VCSRepoOptions) tfe.WorkspaceCreateOptions {
 		description := "Created by tfc-cli"
-		return tfe.WorkspaceCreateOptions{
-			Name:        &name,
-			Description: &description,
+		opts := tfe.WorkspaceCreateOptions{
+			Name:             &name,
+			Description:      &description,
+			WorkingDirectory: &workingDirectory,
+			VCSRepo:          vcsRepoOpts,
+		}
+		return opts
+	})
+	newVCSRepoOptions := (func(identifier string, branch string, oauthTokenId string) *tfe.VCSRepoOptions {
+		return &tfe.VCSRepoOptions{
+			Identifier:   &identifier,
+			Branch:       &branch,
+			OAuthTokenID: &oauthTokenId,
+		}
+	})
+	newDefaultCommandResult := (func() *CommandResult {
+		return &CommandResult{
+			Result: WorkspacesCreateCommandResult{
+				ID:          "someid",
+				Description: "some description",
+			},
 		}
 	})
 	testConfigs := []struct {
@@ -23,8 +42,12 @@ func TestWorkspacesCreate(t *testing.T) {
 		organization          string
 		token                 string
 		workspace             string
+		workingDirectory      string
+		expectedVCSRepoOpts   *tfe.VCSRepoOptions
 		workspaceCreateResult *tfe.Workspace
 		workspaceCreateError  error
+		expectedResultObject  *CommandResult
+		expectedError         error
 	}{
 		{
 			"workspace created",
@@ -32,24 +55,79 @@ func TestWorkspacesCreate(t *testing.T) {
 			"some org",
 			"some token",
 			"foo",
-			&tfe.Workspace{},
+			"",
+			nil,
+			&tfe.Workspace{
+				ID:          "someid",
+				Description: "some description",
+			},
+			nil,
+			newDefaultCommandResult(),
+			nil,
+		},
+		{
+			"with working directory",
+			[]string{"-workspace", "foo", "-working-directory", "somedirectory"},
+			"some org",
+			"some token",
+			"foo",
+			"somedirectory",
+			nil,
+			&tfe.Workspace{
+				ID:          "someid",
+				Description: "some description",
+			},
+			nil,
+			newDefaultCommandResult(),
+			nil,
+		},
+		{
+			"with VCS options",
+			[]string{
+				"-workspace", "foo", "-vcs-identifier", "someorg/somerepo",
+				"-vcs-branch", "somebranch", "-vcs-oauth-token-id", "someoauthtokenid",
+			},
+			"some org",
+			"some token",
+			"foo",
+			"",
+			newVCSRepoOptions("someorg/somerepo", "somebranch", "someoauthtokenid"),
+			&tfe.Workspace{
+				ID:          "someid",
+				Description: "some description",
+			},
+			nil,
+			newDefaultCommandResult(),
 			nil,
 		},
 	}
 	for _, d := range testConfigs {
 		t.Run(d.description, func(t *testing.T) {
 			args := append([]string{"workspaces", "create"}, d.args...)
-			var buff bytes.Buffer
+			var stdBuff, errBuff bytes.Buffer
 			options := ExecuteOpts{
 				AppName: "tfc-cli",
-				Stdout:  &buff,
+				Stdout:  &stdBuff,
+				Stderr:  &errBuff,
 			}
 			// Set up expectations
 			mockedOSProxy := mockOSProxy{}
 			mockedOSProxy.On("lookupEnv", "TFC_ORG").Return(d.organization, true)
 			mockedOSProxy.On("lookupEnv", "TFC_TOKEN").Return(d.token, true)
 			mockedWorkspacesProxy := mockWorkspacesProxy{}
-			mockedWorkspacesProxy.On("create", mock.Anything, mock.Anything, d.organization, newWorkspaceCreateOptions(d.workspace)).Return(d.workspaceCreateResult, d.workspaceCreateError)
+			mockedWorkspacesProxy.On(
+				"create",
+				mock.Anything,
+				mock.Anything,
+				d.organization,
+				newWorkspaceCreateOptions(
+					d.workspace,
+					d.workingDirectory,
+					d.expectedVCSRepoOpts,
+				)).Return(
+				d.workspaceCreateResult,
+				d.workspaceCreateError,
+			)
 
 			// Code under test
 			err := root(
@@ -64,9 +142,21 @@ func TestWorkspacesCreate(t *testing.T) {
 			)
 
 			// Verify
-			assert.Nil(t, err)
 			mockedOSProxy.AssertExpectations(t)
 			mockedWorkspacesProxy.AssertExpectations(t)
+
+			if d.expectedError == nil {
+				assert.Nil(t, err)
+			} else {
+				assert.EqualError(t, err, d.expectedError.Error())
+			}
+			if d.expectedResultObject != nil {
+				expectedOutput, _ := json.Marshal(d.expectedResultObject)
+				expectedOutput = append(expectedOutput, '\n')
+				assert.Equal(t, string(expectedOutput), stdBuff.String())
+			} else {
+				assert.Empty(t, stdBuff.String())
+			}
 		})
 	}
 }

--- a/cmd/workspaces_vcs.go
+++ b/cmd/workspaces_vcs.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+)
+
+type workspacesVCSCmd struct {
+	r    Runner
+	deps dependencyProxies
+	w    io.Writer
+}
+
+func newWorkspacesVCSCmd(deps dependencyProxies, w io.Writer) *workspacesVCSCmd {
+	return &workspacesVCSCmd{
+		deps: deps,
+		w:    w,
+	}
+}
+
+func (c *workspacesVCSCmd) Name() string {
+	return "vcs"
+}
+
+func (c *workspacesVCSCmd) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("no subcommand given")
+	}
+	runners := []Runner{
+		newWorkspacesVCSShowCmd(c.deps, c.w),
+	}
+	return processSubcommand(&c.r, args, runners)
+}
+
+func (c *workspacesVCSCmd) Run() error {
+	return c.r.Run()
+}

--- a/cmd/workspaces_vcs_show.go
+++ b/cmd/workspaces_vcs_show.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"errors"
+	"flag"
+	"io"
+)
+
+type workspacesVCSShowCmd struct {
+	fs   *flag.FlagSet
+	deps dependencyProxies
+	OrgOpts
+	WorkspaceOpts
+	w io.Writer
+}
+
+func newWorkspacesVCSShowCmd(
+	deps dependencyProxies,
+	w io.Writer,
+) *workspacesVCSShowCmd {
+	c := &workspacesVCSShowCmd{
+		fs:   flag.NewFlagSet("show", flag.ContinueOnError),
+		deps: deps,
+		w:    w,
+	}
+	setCommonFlagsetOptions(c.fs, &c.OrgOpts, &c.WorkspaceOpts)
+	return c
+}
+
+func (c *workspacesVCSShowCmd) Name() string {
+	return c.fs.Name()
+}
+
+func (c *workspacesVCSShowCmd) Init(args []string) error {
+	if err := c.fs.Parse(args); err != nil {
+		return err
+	}
+	if err := processCommonInputs(
+		&c.OrgOpts.token,
+		&c.OrgOpts.name,
+		c.deps.os.lookupEnv,
+	); err != nil {
+		return err
+	}
+	if c.WorkspaceOpts.name == "" {
+		return errors.New("-workspace argument is required")
+	}
+	return nil
+}
+
+func (c *workspacesVCSShowCmd) Run() error {
+	return nil
+}

--- a/cmd/workspaces_vcs_show.go
+++ b/cmd/workspaces_vcs_show.go
@@ -52,6 +52,11 @@ func (c *workspacesVCSShowCmd) Init(args []string) error {
 	return nil
 }
 
+type VCSRepoInfo struct {
+	Identifier string `json:"identifier"`
+	Branch     string `json:"branch"`
+}
+
 func (c *workspacesVCSShowCmd) Run() error {
 	ctx := context.Background()
 	client, err := tfe.NewClient(&tfe.Config{
@@ -64,12 +69,20 @@ func (c *workspacesVCSShowCmd) Run() error {
 	if err != nil {
 		return err
 	}
+	var d []byte
 	if w.VCSRepo == nil {
-		d, _ := json.Marshal(CommandResult{
+		d, _ = json.Marshal(CommandResult{
 			Result: "VCS repo not set",
 		})
-		d = append(d, '\n')
-		c.w.Write(d)
+	} else {
+		d, _ = json.Marshal(CommandResult{
+			Result: VCSRepoInfo{
+				Identifier: w.VCSRepo.Identifier,
+				Branch:     w.VCSRepo.Branch,
+			},
+		})
 	}
+	d = append(d, '\n')
+	c.w.Write(d)
 	return nil
 }

--- a/cmd/workspaces_vcs_show.go
+++ b/cmd/workspaces_vcs_show.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
+
+	"github.com/hashicorp/go-tfe"
 )
 
 type workspacesVCSShowCmd struct {
@@ -49,5 +53,23 @@ func (c *workspacesVCSShowCmd) Init(args []string) error {
 }
 
 func (c *workspacesVCSShowCmd) Run() error {
+	ctx := context.Background()
+	client, err := tfe.NewClient(&tfe.Config{
+		Token: c.OrgOpts.token,
+	})
+	if err != nil {
+		return err
+	}
+	w, err := c.deps.client.workspaces.read(client, ctx, c.OrgOpts.name, c.WorkspaceOpts.name)
+	if err != nil {
+		return err
+	}
+	if w.VCSRepo == nil {
+		d, _ := json.Marshal(CommandResult{
+			Result: "VCS repo not set",
+		})
+		d = append(d, '\n')
+		c.w.Write(d)
+	}
 	return nil
 }

--- a/cmd/workspaces_vcs_show_test.go
+++ b/cmd/workspaces_vcs_show_test.go
@@ -52,6 +52,31 @@ func TestWorkspacesVCSShow(t *testing.T) {
 			nil,
 			errors.New("foo"),
 		},
+		{
+			"has VCS info",
+			[]string{"-workspace", "some workspace"},
+			"some org",
+			"some token",
+			"some workspace",
+			"some workspace id",
+			&tfe.Workspace{
+				ID: "some workspace id",
+				VCSRepo: &tfe.VCSRepo{
+					Identifier:   "someorg/somerepo",
+					OAuthTokenID: "someoauthtokenid",
+					Branch:       "somebranch",
+				},
+				WorkingDirectory: "somedirectory",
+			},
+			nil,
+			&CommandResult{
+				Result: VCSRepoInfo{
+					Identifier: "someorg/somerepo",
+					Branch:     "somebranch",
+				},
+			},
+			nil,
+		},
 	}
 	for _, d := range testConfigs {
 		t.Run(d.description, func(t *testing.T) {
@@ -90,9 +115,9 @@ func TestWorkspacesVCSShow(t *testing.T) {
 				assert.EqualError(t, err, d.expectedError.Error())
 			}
 			if d.expectedResultObject != nil {
-				r := CommandResult{}
-				json.Unmarshal(stdBuff.Bytes(), &r)
-				assert.Equal(t, *d.expectedResultObject, r)
+				expectedOutput, _ := json.Marshal(d.expectedResultObject)
+				expectedOutput = append(expectedOutput, '\n')
+				assert.Equal(t, string(expectedOutput), stdBuff.String())
 			} else {
 				assert.Empty(t, stdBuff.String())
 			}

--- a/cmd/workspaces_vcs_show_test.go
+++ b/cmd/workspaces_vcs_show_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestWorkspacesVCSShow(t *testing.T) {
+	testConfigs := []struct {
+		description          string
+		args                 []string
+		organization         string
+		token                string
+		workspace            string
+		workspaceID          string
+		workspaceReadResult  *tfe.Workspace
+		workspaceReadError   error
+		expectedResultObject CommandResult
+	}{
+		{
+			"VCS repo object is nil",
+			[]string{"-workspace", "some workspace"},
+			"some org",
+			"some token",
+			"some workspace",
+			"some workspace id",
+			&tfe.Workspace{
+				ID: "some workspace id",
+			},
+			nil,
+			CommandResult{
+				Result: "VCS repo not set",
+			},
+		},
+	}
+	for _, d := range testConfigs {
+		t.Run(d.description, func(t *testing.T) {
+			args := append([]string{"workspaces", "vcs", "show"}, d.args...)
+			var buff bytes.Buffer
+			options := ExecuteOpts{
+				AppName: "tfc-cli",
+				Stdout:  &buff,
+			}
+			mockedOSProxy := mockOSProxy{}
+			mockedOSProxy.On("lookupEnv", "TFC_ORG").Return(d.organization, true)
+			mockedOSProxy.On("lookupEnv", "TFC_TOKEN").Return(d.token, true)
+			mockedWorkspacesProxy := mockWorkspacesProxy{}
+			mockedWorkspacesProxy.On("read", mock.Anything, mock.Anything, d.organization, d.workspace).Return(d.workspaceReadResult, d.workspaceReadError)
+
+			// Code under test
+			err := root(
+				options,
+				args,
+				dependencyProxies{
+					client: clientProxy{
+						workspaces:         mockedWorkspacesProxy,
+						workspacesCommands: workspacesCommands{
+							// variables: mockedVariablesProxy,
+						},
+					},
+					os: mockedOSProxy,
+				},
+			)
+
+			// Verify
+			assert.Nil(t, err)
+			r := CommandResult{}
+			json.Unmarshal(buff.Bytes(), &r)
+			assert.Equal(t, d.expectedResultObject, r)
+		})
+	}
+}


### PR DESCRIPTION
This feature is to support connecting a Terraform Cloud workspace to an existing GitHub repo/branch upon creation.