### PR TITLE
Bump Go version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,23 +14,23 @@ jobs:
     environment: prod
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
+          go-version: "1.18"
 
       - name: Docker Hub Login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: frostedcarbon
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Updates tooling also, but mainly this is to specify the correct version of go in the GoReleaser step.